### PR TITLE
feat(backend): Added CORS policy to allow requests from all clients

### DIFF
--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -18,7 +18,7 @@ app.add_middleware(
     CORSMiddleware,
     allow_credentials=True,
     allow_methods=["*"],
-    allow_headers=["*"], 
+    allow_headers=["*"],
 )
 
 app.include_router(translate_router)


### PR DESCRIPTION
The web-app frontend was running into the below error
`Access to fetch at 'http://genzlator-api.saichaparala.com:8001/api/v1/translate' from origin 'http://localhost:5173/' has been blocked by CORS policy: Response to preflight request doesn't pass access control check: No 'Access-Control-Allow-Origin' header is present on the requested resource.`

This fix hopes to mediate this issue by allowing requests from all client headers